### PR TITLE
Fix Vercel deployment - Add missing @types/node dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lucide-react": "^0.344.0"
   },
   "devDependencies": {
+    "@types/node": "^20.11.5",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/styled-components": "^5.1.34",


### PR DESCRIPTION
**Problem:**
Vercel build failing with error:
"Please install @types/node by running: npm install --save-dev @types/node"

**Solution:**
Added @types/node ^20.11.5 to devDependencies

**Why:**
Next.js requires @types/node for TypeScript compilation. This was missing from the initial deployment configuration in PR #28.

**Result:**
✅ Vercel builds should now pass
✅ TypeScript compilation will work correctly
✅ Next.js build process can complete successfully

Fixes: PR #28 deployment failure
Related: CEP-23

https://claude.ai/code/session_qx0dJ